### PR TITLE
License and strip notebooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,3 @@
 * text eol=lf
 *.ipynb filter=nbstripout
 *.ipynb diff=ipynb
-* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Dette hindrer at output fra scripts/notebooks lagres i github
-* text eol=lf
+* text=auto eol=lf
 *.ipynb filter=nbstripout
 *.ipynb diff=ipynb
+*.png binary

--- a/EDITH notebook.ipynb
+++ b/EDITH notebook.ipynb
@@ -230,22 +230,14 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Arne Sørli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Oppsett_config_og_database.ipynb
+++ b/Oppsett_config_og_database.ipynb
@@ -102,22 +102,14 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/data_ut.ipynb
+++ b/data_ut.ipynb
@@ -354,15 +354,12 @@
  "metadata": {
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/opprett_kontrolltabell.ipynb
+++ b/opprett_kontrolltabell.ipynb
@@ -272,9 +272,7 @@
    "codemirror_mode": "r",
    "file_extension": ".r",
    "mimetype": "text/x-r-source",
-   "name": "R",
-   "pygments_lexer": "r",
-   "version": "4.1.3"
+   "name": "R"
   }
  },
  "nbformat": 4,

--- a/opprett_tabell_svarinngang.ipynb
+++ b/opprett_tabell_svarinngang.ipynb
@@ -170,15 +170,12 @@
  "metadata": {
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/oppretting_database_raadata.ipynb
+++ b/oppretting_database_raadata.ipynb
@@ -304,15 +304,12 @@
  "metadata": {
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
På denne branchen har jeg rettet opp et par ting:

- [Standard/anbefalt .gitconfig i SSB](https://statistics-norway.atlassian.net/wiki/spaces/KOD/pages/3041493011/Hvordan+konfigurere+git+git+config+etter+SSB-standard) er satt opp til å strippe output og unødvendige metadata fra Jupyter notebooks. Det vil redusere antall mergekonflikter på sikt. På denne greina har jeg strippet alle notebooks med standard .gitconfig.
- NB1! Etter at denne pull requesten er merget, så bør dere sjekke at alle på teamet har standard .gitconfig, for å forhindre at notebooks med unødvendige metadata sniker seg inn igjen. Se beskrivelse på link ovenfor. I praksis betyr det at alle som ikke har endret på .gitconfig på Dapla siden før sommerferien bør kjøre skriptet nevnt på siden.
- NB2! Etter at merge og NB1 er utført, så bør dere strippe output også på de andre aktive greinene. Beskrivelse vil bli lagt ut på [denne siden](https://statistics-norway.atlassian.net/wiki/spaces/~733453743/pages/3211952133/Git+status+viser+endrede+filer+men+git+diff+viser+ingen+endring) i løpet av et par dager.
- Public SSB-repoer skal ha MIT-lisens. Har lagt til lisensfil for det.
- Har fikset opp i at git ikke detekterte ssblogo.png som binær fil.